### PR TITLE
Titlefinder: Inline multiline titles

### DIFF
--- a/webinfo/tests_data/page_with_multiline_title.html
+++ b/webinfo/tests_data/page_with_multiline_title.html
@@ -2,7 +2,12 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>The Ultimate Unicorn</title>
+        <title>The
+            Ultimate
+
+            Unicorn
+
+        </title>
     </head>
     <body>
         This is a page with a title and a unicorn

--- a/webinfo/tests_data/page_with_title_containing_spaces.html
+++ b/webinfo/tests_data/page_with_title_containing_spaces.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>The Ultimate Unicorn</title>
+        <title>    The Ultimate Unicorn </title>
     </head>
     <body>
         This is a page with a title and a unicorn

--- a/webinfo/titlefinder.go
+++ b/webinfo/titlefinder.go
@@ -85,7 +85,6 @@ func HandleURLs(event *irc.Event, callback func(*core.ReplyCallbackData)) {
 
 		title, found := getTitleFromHTML(doc)
 		if found {
-			title = strings.TrimSpace(title)
 			log.Println("Title found: ", title)
 			if helpers.StringInSlice(currentURL.Host, urlShortener) {
 				title += fmt.Sprint(" (", response.Request.URL.String(), ")")
@@ -176,8 +175,12 @@ func getTitleFromHTML(document *html.Node) (title string, found bool) {
 		return
 	}
 
-	// Retrieve the content inside the <title>
-	title = child.FirstChild.Data
+	// Retrieve the content inside the <title> and post-process it
+	title = strings.TrimSpace(child.FirstChild.Data)
+    // Replace every whitespaces or new lines sequence with a single
+    // whitespace
+    re := regexp.MustCompile("\\s+")
+    title = re.ReplaceAllString(title, " ")
 	found = true
 
 	return

--- a/webinfo/titlefinder_test.go
+++ b/webinfo/titlefinder_test.go
@@ -18,9 +18,12 @@ import (
 )
 
 var (
-	htmlWithTitle    = "./tests_data/page_with_title.html"
+    htmlsWithTitle = []string{
+	    "./tests_data/page_with_title.html",
+        "./tests_data/page_with_title_containing_spaces.html",
+        "./tests_data/page_with_multiline_title.html"}
 	htmlWithoutTitle = "./tests_data/page_without_title.html"
-	expectedTitle    = "Unicorn"
+	expectedTitle    = "The Ultimate Unicorn"
 	expectedNick     = "Sender"
 
 	messagesWithUrls = []string{
@@ -48,32 +51,34 @@ var (
 )
 
 func Test_getTitleFromHTML(t *testing.T) {
-	// --- --- --- --- --- --- File with a title
-	fileContent, err := ioutil.ReadFile(htmlWithTitle)
+	// --- --- --- --- --- --- Files with a title
+    for _, fileName := range htmlsWithTitle {
+	    fileContent, err := ioutil.ReadFile(fileName)
+	    if err != nil {
+		    t.Log(err)
+		    t.FailNow()
+	    }
+	    doc, err := html.Parse(strings.NewReader(string(fileContent)))
+	    if err != nil {
+		    t.Log(err)
+		    t.FailNow()
+	    }
+
+	    if title, found := getTitleFromHTML(doc); !found {
+		    t.Errorf("No title found in the document with title %q", expectedTitle)
+	    } else if title != expectedTitle {
+		    t.Errorf("Wrong title found: %q instead of %q", title, expectedTitle)
+	    }
+    }
+	// --- --- --- --- --- ---
+
+	// --- --- --- --- --- --- File without a title
+	fileContent, err := ioutil.ReadFile(htmlWithoutTitle)
 	if err != nil {
 		t.Log(err)
 		t.FailNow()
 	}
 	doc, err := html.Parse(strings.NewReader(string(fileContent)))
-	if err != nil {
-		t.Log(err)
-		t.FailNow()
-	}
-
-	if title, found := getTitleFromHTML(doc); !found {
-		t.Errorf("No title found in the document with title %q", expectedTitle)
-	} else if title != expectedTitle {
-		t.Errorf("Wrong title found: %q instead of %q", title, expectedTitle)
-	}
-	// --- --- --- --- --- ---
-
-	// --- --- --- --- --- --- File without a title
-	fileContent, err = ioutil.ReadFile(htmlWithoutTitle)
-	if err != nil {
-		t.Log(err)
-		t.FailNow()
-	}
-	doc, err = html.Parse(strings.NewReader(string(fileContent)))
 	if err != nil {
 		t.Log(err)
 		t.FailNow()


### PR DESCRIPTION
Replace every whitespace (including \n, \t, ...) sequence with a single
space character. Tests have been added to validate this new behaviour.